### PR TITLE
Revert "Use selection only for <a> tags"

### DIFF
--- a/extension/script.js
+++ b/extension/script.js
@@ -93,8 +93,7 @@ window.SelectLikeABoss = window.SelectLikeABoss || (function() {
 	var movable;
 	var s = document.getSelection();
 	var mainMouseDownHandler = function(e) {
-		var tagName = e.target.tagName.toUpperCase();
-		if (e.which < 2 && tagName === 'A') {
+		if (e.which < 2) {
 			resetVars();
 			var x = e.clientX;
 			var y = e.clientY;


### PR DESCRIPTION
Wasn't such a great idea after all. Try http://jsfiddle.net/xc41ku0p/
