### PR TITLE
Adding Firefox quantum support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,7 @@ modded by Christoph142
 - only handles what needs to be handled
 
 even more like a Boss ;P
+
+jdiaz
+---------
+Enabled Firefox Quantum Support

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,5 +1,5 @@
 {
-   "developer": { "name" :"Dzianis Rusak modded by Christoph142" },
+   "developer": { "name" :"Dzianis Rusak modded by Christoph142, jdiaz" },
    "content_scripts": [ {
       "all_frames": true,
       "js": [ "script.js" ],
@@ -15,8 +15,7 @@
    },
    "manifest_version": 2,
    "name": "Select like a Boss",
-   "offline_enabled": true,
    "permissions": [ "tabs", "<all_urls>" ],
-   "version": "2015",
+   "version": "2018",
    "minimum_chrome_version" : "37"
 }


### PR DESCRIPTION
I removed the offline_enabled property as its the reason why your extension does not work in Firefox quantum. Granted, not sure if you really care for said feature in other browsers which I did not test.